### PR TITLE
Fix: sustitucion de llamadas a categorias.css

### DIFF
--- a/detalle-receta.html
+++ b/detalle-receta.html
@@ -9,7 +9,7 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="css/base.css" />
-    <link rel="stylesheet" href="css/categorias.css" />
+    <link rel="stylesheet" href="css/styles.css" />
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
       rel="stylesheet"

--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
 
   <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
   <script src="js/grafico.js" type="module"></script>
-  <script src="js/categorias.js" type="module"></script>
+  <script src="js/styles.js" type="module"></script>
   <script src="js/buscador.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Muchas referencias a <categorias.css> no habían sido sustituidas por el actual nombre <styles.css>